### PR TITLE
Remove HTTP schema when in non-debug env

### DIFF
--- a/django_project/core/urls.py
+++ b/django_project/core/urls.py
@@ -31,8 +31,8 @@ class CustomSchemaGenerator(OpenAPISchemaGenerator):
     def get_schema(self, request=None, public=False):
         schema = super().get_schema(request, public)
         schema.schemes = ['https']
-        # if settings.DEBUG:
-        schema.schemes = ['http'] + schema.schemes
+        if settings.DEBUG:
+            schema.schemes = ['http'] + schema.schemes
         return schema
 
 


### PR DESCRIPTION
This PR removes HTTP schema when in non-debug env

Prod container:
![image](https://github.com/kartoza/cplus-api/assets/7352963/c109fda1-eb2e-4634-9436-577afb14f40d)

Dev container:
![image](https://github.com/kartoza/cplus-api/assets/7352963/79c1458b-cc7a-4b27-96c8-ef83679c064c)
