### PR TITLE
Prevent new account duplication

### DIFF
--- a/django_project/cplus_api/auth.py
+++ b/django_project/cplus_api/auth.py
@@ -50,7 +50,10 @@ class TrendsEarthAuthentication(authentication.BaseAuthentication):
                 # as username in CPLUS API user table
                 user, created = get_user_model().objects.update_or_create(
                     email=user_profile['email'],
-                    defaults={"first_name": user_profile["name"], "username": user_profile['id']},
+                    defaults={
+                        "first_name": user_profile["name"],
+                        "username": user_profile['id']
+                    },
                 )
                 expiry = (
                     datetime.fromtimestamp(

--- a/django_project/cplus_api/auth.py
+++ b/django_project/cplus_api/auth.py
@@ -48,10 +48,9 @@ class TrendsEarthAuthentication(authentication.BaseAuthentication):
                 # create user based on the user profile
                 # We use Trends.Earth id, which is a UUID Field,
                 # as username in CPLUS API user table
-                user, created = get_user_model().objects.get_or_create(
-                    username=user_profile['id'],
+                user, created = get_user_model().objects.update_or_create(
                     email=user_profile['email'],
-                    first_name=user_profile['name']
+                    defaults={"first_name": user_profile["name"], "username": user_profile['id']},
                 )
                 expiry = (
                     datetime.fromtimestamp(


### PR DESCRIPTION
When users deleted their Trends.Earth account, recreate a new Trends.Earth account, and use it in CPLUS API, CPLUS API should update their old account instead of creating a new one.