### PR TITLE
use PWD instead of relative path in build context devcontainer

### DIFF
--- a/deployment/docker-compose.override.devcontainer.yml
+++ b/deployment/docker-compose.override.devcontainer.yml
@@ -14,7 +14,7 @@ services:
   worker:
     image: kartoza/${COMPOSE_PROJECT_NAME:-django_project}_worker_dev
     build:
-      context: ../
+      context: ${PWD}/
       dockerfile: deployment/docker/Dockerfile
       target: worker
     volumes:
@@ -25,7 +25,7 @@ services:
   celery_beat:
     image: kartoza/${COMPOSE_PROJECT_NAME:-django_project}_worker_dev
     build:
-      context: ../
+      context: ${PWD}/
       dockerfile: deployment/docker/Dockerfile
       target: worker
     volumes:
@@ -35,7 +35,7 @@ services:
   dev:
     image: kartoza/${COMPOSE_PROJECT_NAME:-django_project}_dev
     build:
-      context: ../
+      context: ${PWD}/
       dockerfile: deployment/docker/Dockerfile
       target: vscode
     entrypoint: []


### PR DESCRIPTION
The vscode is failed to build images with following error: cannot find Dockerfile.
`Error: ENOENT: no such file or directory, open '/home/danang/.vscode-remote-containers/dist/deployment/docker/Dockerfile'`

This could be vscode cannot determine the correct build context.
VSCode version
![image](https://github.com/kartoza/cplus-api/assets/5819076/eb290980-b263-4624-b30a-836195a72811)

DevContainer version: v0.369.0
WSL version:
![image](https://github.com/kartoza/cplus-api/assets/5819076/7ee7be51-9ba4-440d-859b-e072a71f128d)
