### PR TITLE
Update logs endpoint

### DIFF
--- a/django_project/cplus_api/serializers/scenario.py
+++ b/django_project/cplus_api/serializers/scenario.py
@@ -425,7 +425,7 @@ class ScenarioTaskStatusSerializer(serializers.ModelSerializer):
         return TaskLog.objects.filter(
             content_type=scenario_task_ct,
             object_id=obj.pk
-        ).order_by('date_time').values_list('log', flat=True)
+        ).order_by('date_time').values('log', 'date_time')
 
     class Meta:
         swagger_schema_fields = {


### PR DESCRIPTION
This is PR for https://github.com/ConservationInternational/cplus-plugin/issues/455.
In order to show logs with server datetime in Processing Logs, we need date_time info from log.