### PR TITLE
Fix is_raster in common layer

### DIFF
--- a/django_project/cplus_api/tasks/sync_default_layers.py
+++ b/django_project/cplus_api/tasks/sync_default_layers.py
@@ -85,7 +85,7 @@ class ProcessFile:
             nodata = dataset.nodata
 
             metadata = {
-                "is_raster": get_layer_type(file_path) == 0,
+                "is_raster": get_layer_type(self.file['Key']) == 0,
                 "crs": str(crs),
                 "resolution": [res_x, res_y],
                 "no_data": nodata


### PR DESCRIPTION
When filepath is updated to tmp file, `is_raster` attrbute in input layer metadata could get wrong value. Use file key from S3 instead 