### PR TITLE
Skip non cplus layer on syncing cplus lyers

### DIFF
--- a/django_project/cplus_api/tests/test_sync_default_layers.py
+++ b/django_project/cplus_api/tests/test_sync_default_layers.py
@@ -387,19 +387,20 @@ class TestSyncDefaultLayer(BaseAPIViewTransactionTest):
         belongs to Naturebase.
         """
         input_layer, source_path, dest_path = self.base_run()
+        InputLayer.objects.update(source=InputLayer.LayerSources.NATURE_BASE)
         copyfile(source_path, dest_path)
         input_layer.source = InputLayer.LayerSources.NATURE_BASE
         input_layer.save()
 
         sync_default_layers()
 
-        all_layer_sources = list(
+        all_layer_sources = set(
             InputLayer.objects.values_list('source', flat=True)
         )
 
         # Check that there is only Naturebase Input layers
         self.assertEqual(
-            all_layer_sources, [InputLayer.LayerSources.NATURE_BASE]
+            all_layer_sources, {InputLayer.LayerSources.NATURE_BASE}
         )
 
     @patch(

--- a/django_project/cplus_api/tests/test_sync_default_layers.py
+++ b/django_project/cplus_api/tests/test_sync_default_layers.py
@@ -393,10 +393,14 @@ class TestSyncDefaultLayer(BaseAPIViewTransactionTest):
 
         sync_default_layers()
 
-        all_layer_sources = list(InputLayer.objects.values_list('source', flat=True))
+        all_layer_sources = list(
+            InputLayer.objects.values_list('source', flat=True)
+        )
 
         # Check that there is only Naturebase Input layers
-        self.assertEqual(all_layer_sources, [InputLayer.LayerSources.NATURE_BASE])
+        self.assertEqual(
+            all_layer_sources, [InputLayer.LayerSources.NATURE_BASE]
+        )
 
     @patch(
         'cplus_api.utils.layers.sync_nature_base',
@@ -415,10 +419,16 @@ class TestSyncDefaultLayer(BaseAPIViewTransactionTest):
         copyfile(source_path, dest_path)
         input_layer.source = InputLayer.LayerSources.NATURE_BASE
         input_layer.save()
-        with patch('cplus_api.utils.layers.select_input_layer_storage') as mock_storage:
+        with patch(
+                'cplus_api.utils.layers.select_input_layer_storage'
+        ) as mock_storage:
             self.run_s3(mock_storage)
 
-        all_layer_sources = list(InputLayer.objects.values_list('source', flat=True))
+        all_layer_sources = list(
+            InputLayer.objects.values_list('source', flat=True)
+        )
 
         # Check that there is only Naturebase Input layers
-        self.assertEqual(all_layer_sources, [InputLayer.LayerSources.NATURE_BASE])
+        self.assertEqual(
+            all_layer_sources, [InputLayer.LayerSources.NATURE_BASE]
+        )


### PR DESCRIPTION
This PR fixes naturebase layer sync where some of their source are changed to CPLUS, instead of Naturebase.